### PR TITLE
Add a delay after moving across cell boundaries, and don't change if we're playing from the same soundbank

### DIFF
--- a/scripts/DynamicMusic/player.lua
+++ b/scripts/DynamicMusic/player.lua
@@ -70,6 +70,15 @@ local function getPlayerState()
   return PlayerStates.explore
 end
 
+local PlayerMovedTimer
+
+local function PlayerMoved()
+  if GameState.soundbank.current ~= GameState.soundbank.previous then
+    PlayerMovedTimer = 4
+  end
+end
+
+
 local function hasGameStateChanged()
   if GameState.playerState.previous ~= GameState.playerState.current then
     -- print("change playerState: " ..gameState.playerState.current)
@@ -82,11 +91,16 @@ local function hasGameStateChanged()
 
   if GameState.regionName.current ~= GameState.regionName.previous then
     -- print("change regionName")
-    return true
+    PlayerMoved()
   end
 
   if GameState.cellName.current ~= GameState.cellName.previous then
     -- print("change celName")
+    PlayerMoved()
+  end
+
+  if PlayerMovedTimer and PlayerMovedTimer <= 0 then
+    PlayerMovedTimer = nil
     return true
   end
 
@@ -120,6 +134,9 @@ local function onFrame(dt)
   end
 
   local hourOfDay = math.floor((core.getGameTime() / 3600) % 24)
+  if PlayerMovedTimer and PlayerMovedTimer > 0 then
+    PlayerMovedTimer = PlayerMovedTimer - dt
+  end
 
   GameState.exterior.current = self.cell and self.cell.isExterior
   GameState.cellName.current = self.cell and self.cell.name or ""


### PR DESCRIPTION
When you're moving near the corner of a cell, it's possible to cross two or even three cell boundaries in short succession while navigating around, which causes DM to stop and start each time. That was annoying, so I added a short delay before it changes the music, so you get one change instead of three.

 With the delay, Icarian Flight shouldn't change the music until after you hit the ground, as each cell crossed in under four seconds will restart the timer.

 I also made it not change the music if the soundbank of the new cell(s) match the previous one. This will revert to changing back and forth if you're moving across corners where the soundbank changes even briefly, even though you land in a cell with the same soundbank as you had before the change; adding that would be nice but this is good enough for me as is.
